### PR TITLE
Changes in grid column width are now saved in user settings as int[].

### DIFF
--- a/UnityLauncher/App.config
+++ b/UnityLauncher/App.config
@@ -33,6 +33,13 @@
             <setting name="closeAfterProject" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="gridColumnWidths" serializeAs="Xml">
+              <value>
+                <ArrayOfInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                </ArrayOfInt>
+              </value>
+          </setting>
         </UnityLauncher.Properties.Settings>
     </userSettings>
 </configuration>

--- a/UnityLauncher/Form1.cs
+++ b/UnityLauncher/Form1.cs
@@ -88,6 +88,8 @@ namespace UnityLauncher
 
             // preselect grid
             gridRecent.Select();
+
+            this.gridRecent.ColumnWidthChanged += new System.Windows.Forms.DataGridViewColumnEventHandler(this.gridRecent_ColumnWidthChanged);
         }
 
         void LoadSettings()
@@ -101,6 +103,13 @@ namespace UnityLauncher
             lstRootFolders.Items.AddRange(Properties.Settings.Default.rootFolders.Cast<string>().ToArray());
             // update packages folder listbox
             lstPackageFolders.Items.AddRange(Properties.Settings.Default.packageFolders.Cast<string>().ToArray());
+
+            // restore data grid view widths
+            int[] gridColumnWidths = Properties.Settings.Default.gridColumnWidths;
+            for ( int i=0; i< gridColumnWidths.Length; ++i )
+            {
+                gridRecent.Columns[i].Width = gridColumnWidths[i];
+            }
         }
 
         /// <summary>
@@ -922,6 +931,27 @@ namespace UnityLauncher
             {
                 LaunchExplorer(logfolder);
             }
+        }
+
+        private void gridRecent_ColumnWidthChanged(object sender, DataGridViewColumnEventArgs e)
+        {
+            List<int> gridWidths = new List<int>(Properties.Settings.Default.gridColumnWidths);
+            // restore data grid view widths
+            var colum = gridRecent.Columns[0];
+            int a = Properties.Settings.Default.gridColumnWidths.Length;
+            for (int i = 0; i < gridRecent.Columns.Count; ++i)
+            {
+                if (Properties.Settings.Default.gridColumnWidths.Length > i)
+                {
+                    gridWidths[i] = gridRecent.Columns[i].Width;
+                }
+                else
+                {
+                    gridWidths.Add(gridRecent.Columns[i].Width);
+                }
+            }
+            Properties.Settings.Default.gridColumnWidths = gridWidths.ToArray();
+            Properties.Settings.Default.Save();
         }
         #endregion UI events
 

--- a/UnityLauncher/Properties/Settings.Designer.cs
+++ b/UnityLauncher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace UnityLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -83,6 +83,23 @@ namespace UnityLauncher.Properties {
             }
             set {
                 this["closeAfterProject"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfInt xmlns:xsi=\"http://www.w3." +
+            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <i" +
+            "nt>100</int>\r\n</ArrayOfInt>")]
+        public int[] gridColumnWidths
+        {
+            get
+            {
+                return ((int[])(this["gridColumnWidths"]));
+            }
+            set
+            {
+                this["gridColumnWidths"] = value;
             }
         }
     }

--- a/UnityLauncher/Properties/Settings.settings
+++ b/UnityLauncher/Properties/Settings.settings
@@ -21,5 +21,11 @@
     <Setting Name="closeAfterProject" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="gridColumnWidths" Type="System.String" Scope="User">
+      <Value Profile="(Default)">
+                &lt;ArrayOfInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+                &lt;/ArrayOfInt&gt;
+              </Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
I have added them as an int[]. The Settings Designer UI in Visual Studio 2017 does not really like it though. Just click "No" if it asks to update the settings file. Maybe there is a better solution for VS2017? - It works just fine in the final program.