### PR TITLE
Fix exception thrown when run from command line

### DIFF
--- a/UnityLauncher/Form1.cs
+++ b/UnityLauncher/Form1.cs
@@ -1128,10 +1128,10 @@ namespace UnityLauncher
         string GetSelectedRowData(string key)
         {
             string path = null;
-            var selected = gridRecent.CurrentCell.RowIndex;
-            if (selected > -1)
+            var selected = gridRecent?.CurrentCell?.RowIndex;
+            if (selected.HasValue && selected > -1)
             {
-                path = gridRecent.Rows[selected].Cells[key].Value?.ToString();
+                path = gridRecent.Rows[selected.Value].Cells[key].Value?.ToString();
             }
             return path;
         }


### PR DESCRIPTION
Opening project from command line doesn't work because exception is
thrown when trying to launch the application. Exception occurs because
application is trying to retrieve _launchArguments for the row of the
currently selected cell. When running from command line currently
selected cell is null and that causes a null reference exception to
occur.

Issue is fixed by checking the current grid and cell for null and
handling the situation like no row has been selected.