### PR TITLE
Support relative paths from command line

### DIFF
--- a/UnityLauncher/Form1.cs
+++ b/UnityLauncher/Form1.cs
@@ -73,6 +73,12 @@ namespace UnityLauncher
                     // path
                     var projectPathArgument = args[2];
 
+                    // resolve full path if path parameter isn't a rooted path
+                    if (!Path.IsPathRooted(projectPathArgument))
+                    {
+                        projectPathArgument = Directory.GetCurrentDirectory() + projectPathArgument;
+                    }
+
                     var version = Tools.GetProjectVersion(projectPathArgument);
 
                     // take extra arguments also


### PR DESCRIPTION
Add support for providing product path argument as relative path. This
makes it easier to open projects from command line as user doesn't need
to provide full path to project directory. It also allows opening the
project from current directory by providing . as path argument.

Check for relative path is done with just checking if the path isn't a
rooted path. If more thorough checks are needed, this StackOverflow
thread has discussion on how the current check could be extended.

https://stackoverflow.com/questions/5565029/check-if-full-path-given/35046453