### PR TITLE
Allowing override of Project Version with a text file

### DIFF
--- a/UnityLauncher/Tools.cs
+++ b/UnityLauncher/Tools.cs
@@ -251,7 +251,12 @@ namespace UnityLauncherTools
         public static string GetProjectVersion(string path)
         {
             var version = "";
-            if (Directory.Exists(Path.Combine(path, "ProjectSettings")))
+
+            if(File.Exists(Path.Combine(path, "ProjectVersionOverride.txt")))
+            {
+                version = File.ReadAllText(Path.Combine(path, "ProjectVersionOverride.txt"));
+            }
+            else if (Directory.Exists(Path.Combine(path, "ProjectSettings")))
             {
                 var versionPath = Path.Combine(path, "ProjectSettings", "ProjectVersion.txt");
                 if (File.Exists(versionPath) == true) // 5.x and later


### PR DESCRIPTION
This commit adds support for overriding the Unity Version that will be used for a project by reading from a file called "ProjectVersionOverride.txt" in the root directory of a project.

My use case for this feature is having multiple copies of the same project which has the Assets folder and ProjectSettings folder sym-linked to a shared directory. When pulling from Git, it will update the Assets and ProjectSettings automatically for multiple Unity Project folders.

I do it this way because I need to have a separate version of Unity being used for different platforms - e.g. Console builds require a specific version / patch version of Unity, but the PC version needs a separate version. By reading from the file in ProjectSettings, it will be copied across to all my shared projects via the symlinks. However, having this special override file outside of the ProjectSettings directory (in the root of the project) will allow me to use the UnityLauncher and keep track of the exact version needed for each platform of a project even if the data in ProjectSettings is different from this.

If there is no file named "ProjectVersionOverride.txt" in the root of the project, then it will check the Unity project version as normal without using this extra check.